### PR TITLE
Agent の削除機能を追加

### DIFF
--- a/src/rvosimulator/go.mod
+++ b/src/rvosimulator/go.mod
@@ -1,1 +1,3 @@
 module github.com/RuiHirano/rvo2-go/src/rvosimulator
+
+go 1.13

--- a/src/rvosimulator/kdtree.go
+++ b/src/rvosimulator/kdtree.go
@@ -73,6 +73,7 @@ func NewKdTree() *KdTree {
 
 // BuildAgentTree :
 func (kt *KdTree) BuildAgentTree() {
+	kt.Agents = nil
 	if len(kt.Agents) < len(Sim.Agents) {
 		for i := len(kt.Agents); i < len(Sim.Agents); i++ {
 
@@ -394,14 +395,14 @@ func (kt *KdTree) QueryObstacleTreeRecursive(agent *Agent, rangeSq float64, node
 
 		var agentLeftOfLine, distSqLine float64
 		agentLeftOfLine = LeftOf(obstacle1.Point, obstacle2.Point, agent.Position)
-		
+
 		var tNode *ObstacleTreeNode
 		if agentLeftOfLine >= 0 {
 			tNode = node.Left
 		} else {
 			tNode = node.Right
 		}
-		
+
 		kt.QueryObstacleTreeRecursive(agent, rangeSq, tNode)
 
 		distSqLine = math.Pow(agentLeftOfLine, 2) / Sqr(Sub(obstacle2.Point, obstacle1.Point))
@@ -420,7 +421,6 @@ func (kt *KdTree) QueryObstacleTreeRecursive(agent *Agent, rangeSq float64, node
 				t2Node = node.Left
 			}
 			kt.QueryObstacleTreeRecursive(agent, rangeSq, t2Node)*/
-			
 
 		}
 

--- a/src/rvosimulator/rvosimulator.go
+++ b/src/rvosimulator/rvosimulator.go
@@ -121,12 +121,22 @@ func (rvo *RVOSimulator) AddAgent(position *Vector2, neighborDist float64, maxNe
 	return agent.ID, false
 }
 
-// RemoveAgent : Remove agent by id
-func (rvo *RVOSimulator) RemoveAgent(id int) bool {
+// RemoveAgent : Remove agent by agentNo
+func (rvo *RVOSimulator) RemoveAgent(agentNo int) bool {
 
-	rvo.Agents = append(rvo.Agents[:id], rvo.Agents[id+1:]...)
+	rvo.Agents = append(rvo.Agents[:agentNo], rvo.Agents[agentNo+1:]...)
 
 	return false
+}
+
+// GetAgentNoByID : Get Agent No. by Agent ID
+func (rvo *RVOSimulator) GetAgentNoByID(id int) int {
+	for i := 0; i < rvo.GetNumAgents(); i++ {
+		if rvo.GetAgent(i).ID == id {
+			return i
+		}
+	}
+	return -1
 }
 
 // AddObstacle : Add Obstacle with vertices

--- a/src/rvosimulator/rvosimulator.go
+++ b/src/rvosimulator/rvosimulator.go
@@ -9,13 +9,14 @@ func init() {
 
 // RVOSimulator :
 type RVOSimulator struct {
-	TimeStep     float64
-	Agents       []*Agent
-	Obstacles    [][]*Vector2
-	ObstacleVertices    []*Obstacle
-	KdTree       *KdTree
-	DefaultAgent *Agent
-	GlobalTime   float64
+	TimeStep         float64
+	Agents           []*Agent
+	Obstacles        [][]*Vector2
+	ObstacleVertices []*Obstacle
+	KdTree           *KdTree
+	DefaultAgent     *Agent
+	GlobalTime       float64
+	NextAgentID      int
 }
 
 // NewRVOSimulator : RVOSimulator with options
@@ -32,13 +33,14 @@ func NewRVOSimulator(timeStep float64, neighborDist float64, maxNeighbors int, t
 	defaultAgent.Velocity = velocity
 
 	sim := &RVOSimulator{
-		TimeStep:     timeStep,
-		Agents:       make([]*Agent, 0),
-		Obstacles:    make([][]*Vector2, 0),
-		ObstacleVertices:    make([]*Obstacle, 0),
-		KdTree:       kdTree,
-		DefaultAgent: defaultAgent,
-		GlobalTime:   0.0,
+		TimeStep:         timeStep,
+		Agents:           make([]*Agent, 0),
+		Obstacles:        make([][]*Vector2, 0),
+		ObstacleVertices: make([]*Obstacle, 0),
+		KdTree:           kdTree,
+		DefaultAgent:     defaultAgent,
+		GlobalTime:       0.0,
+		NextAgentID:      0,
 	}
 	Sim = sim
 
@@ -51,13 +53,13 @@ func NewEmptyRVOSimulator() *RVOSimulator {
 	defaultAgent := NewEmptyAgent()
 
 	sim := &RVOSimulator{
-		TimeStep:     0,
-		Agents:       make([]*Agent, 0),
-		Obstacles:    make([][]*Vector2, 0),
-		ObstacleVertices:    make([]*Obstacle, 0),
-		KdTree:       kdTree,
-		DefaultAgent: defaultAgent,
-		GlobalTime:   0.0,
+		TimeStep:         0,
+		Agents:           make([]*Agent, 0),
+		Obstacles:        make([][]*Vector2, 0),
+		ObstacleVertices: make([]*Obstacle, 0),
+		KdTree:           kdTree,
+		DefaultAgent:     defaultAgent,
+		GlobalTime:       0.0,
 	}
 	Sim = sim
 	return sim
@@ -91,11 +93,12 @@ func (rvo *RVOSimulator) AddDefaultAgent(position *Vector2) (int, bool) {
 	agent.TimeHorizon = rvo.DefaultAgent.TimeHorizon
 	agent.TimeHorizonObst = rvo.DefaultAgent.TimeHorizonObst
 	agent.Velocity = rvo.DefaultAgent.Velocity
-	agent.ID = len(rvo.Agents)
+	agent.ID = rvo.NextAgentID
 
 	rvo.Agents = append(rvo.Agents, agent)
+	rvo.NextAgentID++
 
-	return len(rvo.Agents) - 1, false
+	return agent.ID, false
 }
 
 // AddAgent : Add agent with options
@@ -110,11 +113,20 @@ func (rvo *RVOSimulator) AddAgent(position *Vector2, neighborDist float64, maxNe
 	agent.TimeHorizon = timeHorizon
 	agent.TimeHorizonObst = timeHorizonObst
 	agent.Velocity = velocity
-	agent.ID = len(rvo.Agents)
+	agent.ID = rvo.NextAgentID
 
 	rvo.Agents = append(rvo.Agents, agent)
+	rvo.NextAgentID++
 
-	return len(rvo.Agents) - 1, false
+	return agent.ID, false
+}
+
+// RemoveAgent : Remove agent by id
+func (rvo *RVOSimulator) RemoveAgent(id int) bool {
+
+	rvo.Agents = append(rvo.Agents[:id], rvo.Agents[id+1:]...)
+
+	return false
 }
 
 // AddObstacle : Add Obstacle with vertices
@@ -147,7 +159,6 @@ func (rvo *RVOSimulator) AddObstacle(vertices []*Vector2) (int, bool) {
 			obstacle.NextObstacle = rvo.ObstacleVertices[obstacleNo]
 			obstacle.NextObstacle.PrevObstacle = obstacle
 		}
-		
 
 		var ti int
 		if i == len(vertices)-1 {
@@ -226,12 +237,12 @@ func (rvo *RVOSimulator) GetAgentGoalVector(agentNo int) *Vector2 {
 	return Normalize(Sub(rvo.GetAgentGoal(agentNo), rvo.GetAgentPosition(agentNo)))
 }
 
-// GetAgents:
+// GetAgents :
 func (rvo *RVOSimulator) GetAgents() []*Agent {
 	return rvo.Agents
 }
 
-// GetAgent:
+// GetAgent :
 func (rvo *RVOSimulator) GetAgent(agentNo int) *Agent {
 	return rvo.Agents[agentNo]
 }
@@ -363,7 +374,7 @@ func (rvo *RVOSimulator) GetNumObstacles() int {
 	return len(rvo.Obstacles)
 }
 
-// GetObstacle:
+// GetObstacle :
 func (rvo *RVOSimulator) GetObstacle(obstacleNo int) []*Vector2 {
 	return rvo.Obstacles[obstacleNo]
 }


### PR DESCRIPTION
元の RVO2 にはありませんが、動的に Agent を削除する機能を追加しました。

1ステップごとに Agent が削除される可能性があるため、 `src/rvosimulator/kdtree.go` 内の `BuildAgentTree()` で `kt.Agents = nil` させています。
(必要かどうかはよくわかりません)